### PR TITLE
Fixed “load_tables” function in load.py file

### DIFF
--- a/tpch4pgsql/load.py
+++ b/tpch4pgsql/load.py
@@ -87,7 +87,7 @@ def load_tables(data_dir, host, port, db_name, user, password, tables, load_dir)
         try:
             for table in tables:
                 filepath = os.path.join(data_dir, load_dir, table.lower() + ".tbl.csv")
-                conn.copyFrom(filepath, separator="|", table=table)
+                conn.copyFrom(filepath, separator="|", table=table.lower())
             conn.commit()
         except Exception as e:
             print("unable to run load tables. %s" %e)


### PR DESCRIPTION
Hi,

Made the following update in load_tables function in load.py file to resolve errors during load step of TPC-H benchmark execution. Updated "table" to "table.lower()"

conn.copyFrom(filepath, separator="|", table=table.lower())

Thanks and Regards,